### PR TITLE
Warning box about conda envs and code snippet fix 

### DIFF
--- a/docs/guide/data/pre-generated/ESDC.md
+++ b/docs/guide/data/pre-generated/ESDC.md
@@ -3,7 +3,11 @@
 ## How to open this dataset in DeepESDL JupyterLab
 ```python
 from xcube.core.store import new_data_store
-store = new_data_store("s3", root="deep-esdl-public", storage_options=dict(anon=True))
+store = new_data_store("s3",
+                       root="deep-esdl-public",
+                       storage_options=dict(anon=False,
+                                            key=S3_USER_STORAGE_KEY,
+                                            secret=S3_USER_STORAGE_SECRET))
 ds = store.open_data('esdc-8d-0.25deg-1x720x1440-3.0.1.zarr')
 ```
 

--- a/docs/guide/data/pre-generated/LC-1x2025x2025-2-0-0-levels.md
+++ b/docs/guide/data/pre-generated/LC-1x2025x2025-2-0-0-levels.md
@@ -3,7 +3,11 @@
 ## How to open this dataset in DeepESDL JupyterLab
 ```python
 from xcube.core.store import new_data_store
-store = new_data_store("s3", root="deep-esdl-public", storage_options=dict(anon=True))
+store = new_data_store("s3",
+                       root="deep-esdl-public",
+                       storage_options=dict(anon=False,
+                                            key=S3_USER_STORAGE_KEY,
+                                            secret=S3_USER_STORAGE_SECRET))
 # The cube is saved as a multilevel cube, the level 0 is the base layer with 
 # the highest resolution
 ml_dataset = store.open_data('LC-1x2025x2025-2.0.0.levels')

--- a/docs/guide/data/pre-generated/SMOS-L2C-OS-20230101-20231231-1W-res0-1x1000x1000-levels.md
+++ b/docs/guide/data/pre-generated/SMOS-L2C-OS-20230101-20231231-1W-res0-1x1000x1000-levels.md
@@ -3,7 +3,11 @@
 ## How to open this dataset in DeepESDL JupyterLab
 ```python
 from xcube.core.store import new_data_store
-store = new_data_store("s3", root="deep-esdl-public", storage_options=dict(anon=True))
+store = new_data_store("s3",
+                       root="deep-esdl-public",
+                       storage_options=dict(anon=False,
+                                            key=S3_USER_STORAGE_KEY,
+                                            secret=S3_USER_STORAGE_SECRET))
 ds = store.open_data('SMOS-L2C-OS-20230101-20231231-1W-res0-1x1000x1000.levels')
 ```
 

--- a/docs/guide/data/pre-generated/SMOS-L2C-SM-20230101-20231231-1W-res0-1x1000x1000-levels.md
+++ b/docs/guide/data/pre-generated/SMOS-L2C-SM-20230101-20231231-1W-res0-1x1000x1000-levels.md
@@ -3,7 +3,11 @@
 ## How to open this dataset in DeepESDL JupyterLab
 ```python
 from xcube.core.store import new_data_store
-store = new_data_store("s3", root="deep-esdl-public", storage_options=dict(anon=True))
+store = new_data_store("s3",
+                       root="deep-esdl-public",
+                       storage_options=dict(anon=False,
+                                            key=S3_USER_STORAGE_KEY,
+                                            secret=S3_USER_STORAGE_SECRET))
 ds = store.open_data('SMOS-L2C-SM-20230101-20231231-1W-res0-1x1000x1000.levels')
 ```
 

--- a/docs/guide/data/pre-generated/SMOS-snow-1x720x720-1-0-1-zarr.md
+++ b/docs/guide/data/pre-generated/SMOS-snow-1x720x720-1-0-1-zarr.md
@@ -3,7 +3,11 @@
 ## How to open this dataset in DeepESDL JupyterLab
 ```python
 from xcube.core.store import new_data_store
-store = new_data_store("s3", root="deep-esdl-public", storage_options=dict(anon=True))
+store = new_data_store("s3",
+                       root="deep-esdl-public",
+                       storage_options=dict(anon=False,
+                                            key=S3_USER_STORAGE_KEY,
+                                            secret=S3_USER_STORAGE_SECRET))
 ds = store.open_data('SMOS-snow-1x720x720-1.0.1.zarr')
 ```
 

--- a/docs/guide/data/pre-generated/SeasFireCube_v3-zarr.md
+++ b/docs/guide/data/pre-generated/SeasFireCube_v3-zarr.md
@@ -3,7 +3,11 @@
 ## How to open this dataset in DeepESDL JupyterLab
 ```python
 from xcube.core.store import new_data_store
-store = new_data_store("s3", root="deep-esdl-public", storage_options=dict(anon=True))
+store = new_data_store("s3",
+                       root="deep-esdl-public",
+                       storage_options=dict(anon=False,
+                                            key=S3_USER_STORAGE_KEY,
+                                            secret=S3_USER_STORAGE_SECRET))
 ds = store.open_data('SeasFireCube_v3.zarr')
 ```
 

--- a/docs/guide/data/pre-generated/black-sea.md
+++ b/docs/guide/data/pre-generated/black-sea.md
@@ -3,7 +3,11 @@
 ## How to open this dataset in DeepESDL JupyterLab
 ```python
 from xcube.core.store import new_data_store
-store = new_data_store("s3", root="deep-esdl-public", storage_options=dict(anon=True))
+store = new_data_store("s3",
+                       root="deep-esdl-public",
+                       storage_options=dict(anon=False,
+                                            key=S3_USER_STORAGE_KEY,
+                                            secret=S3_USER_STORAGE_SECRET))
 # The cube is saved as a multilevel cube, the level 0 is the base layer with 
 # the highest resolution
 ml_dataset = store.open_data('black-sea-1x1024x1024.levels')

--- a/docs/guide/data/pre-generated/esa-cci-permafrost-1x1151x1641-0-0-2-zarr.md
+++ b/docs/guide/data/pre-generated/esa-cci-permafrost-1x1151x1641-0-0-2-zarr.md
@@ -3,7 +3,11 @@
 ## How to open this dataset in DeepESDL JupyterLab
 ```python
 from xcube.core.store import new_data_store
-store = new_data_store("s3", root="deep-esdl-public", storage_options=dict(anon=True))
+store = new_data_store("s3",
+                       root="deep-esdl-public",
+                       storage_options=dict(anon=False,
+                                            key=S3_USER_STORAGE_KEY,
+                                            secret=S3_USER_STORAGE_SECRET))
 # The cube is saved as a multilevel cube, the level 0 is the base layer with 
 # the highest resolution
 ml_dataset = store.open_data('esa-cci-permafrost-1x1151x1641-0.0.2.levels')

--- a/docs/guide/data/pre-generated/extrAIM-merged-cube-1x86x179-zarr.md
+++ b/docs/guide/data/pre-generated/extrAIM-merged-cube-1x86x179-zarr.md
@@ -3,7 +3,11 @@
 ## How to open this dataset in DeepESDL JupyterLab
 ```python
 from xcube.core.store import new_data_store
-store = new_data_store("s3", root="deep-esdl-public", storage_options=dict(anon=True))
+store = new_data_store("s3",
+                       root="deep-esdl-public",
+                       storage_options=dict(anon=False,
+                                            key=S3_USER_STORAGE_KEY,
+                                            secret=S3_USER_STORAGE_SECRET))
 ds = store.open_data('extrAIM-merged-cube-1x86x179.zarr')
 ```
 

--- a/docs/guide/data/pre-generated/hydrology-1D-0-009deg-100x60x60-3-0-2-zarr.md
+++ b/docs/guide/data/pre-generated/hydrology-1D-0-009deg-100x60x60-3-0-2-zarr.md
@@ -3,7 +3,11 @@
 ## How to open this dataset in DeepESDL JupyterLab
 ```python
 from xcube.core.store import new_data_store
-store = new_data_store("s3", root="deep-esdl-public", storage_options=dict(anon=True))
+store = new_data_store("s3",
+                       root="deep-esdl-public",
+                       storage_options=dict(anon=False,
+                                            key=S3_USER_STORAGE_KEY,
+                                            secret=S3_USER_STORAGE_SECRET))
 ds = store.open_data('hydrology-1D-0.009deg-100x60x60-3.0.2.zarr')
 ```
 

--- a/docs/guide/data/pre-generated/index.md
+++ b/docs/guide/data/pre-generated/index.md
@@ -25,8 +25,11 @@ dedicated example [Jupyter Notebook](../../jupyterlab/notebooks/generic-notebook
 Initializing the xcube datastore for s3 object storage:
 ```python
 from xcube.core.store import new_data_store
-store = new_data_store("s3", 
-                       root="deep-esdl-public")
+store = new_data_store("s3",
+                       root="deep-esdl-public",
+                       storage_options=dict(anon=False,
+                                            key=S3_USER_STORAGE_KEY,
+                                            secret=S3_USER_STORAGE_SECRET))
 ```
 List all available datasets:
 

--- a/docs/guide/data/pre-generated/ocean-1M-9km-1x1080x1080-1-4-0-zarr.md
+++ b/docs/guide/data/pre-generated/ocean-1M-9km-1x1080x1080-1-4-0-zarr.md
@@ -3,7 +3,11 @@
 ## How to open this dataset in DeepESDL JupyterLab
 ```python
 from xcube.core.store import new_data_store
-store = new_data_store("s3", root="deep-esdl-public", storage_options=dict(anon=True))
+store = new_data_store("s3",
+                       root="deep-esdl-public",
+                       storage_options=dict(anon=False,
+                                            key=S3_USER_STORAGE_KEY,
+                                            secret=S3_USER_STORAGE_SECRET))
 # The cube is saved as a multilevel cube, the level 0 is the base layer with 
 # the highest resolution
 ml_dataset = store.open_data('ocean-1M-9km-1x1080x1080-1.4.0.levels')

--- a/docs/guide/data/pre-generated/polar-100m-1x2048x2048-1-0-1-zarr.md
+++ b/docs/guide/data/pre-generated/polar-100m-1x2048x2048-1-0-1-zarr.md
@@ -3,7 +3,11 @@
 ## How to open this dataset in DeepESDL JupyterLab
 ```python
 from xcube.core.store import new_data_store
-store = new_data_store("s3", root="deep-esdl-public", storage_options=dict(anon=True))
+store = new_data_store("s3",
+                       root="deep-esdl-public",
+                       storage_options=dict(anon=False,
+                                            key=S3_USER_STORAGE_KEY,
+                                            secret=S3_USER_STORAGE_SECRET))
 ds = store.open_data('polar-100m-1x2048x2048-1.0.1.zarr')
 ```
 

--- a/docs/guide/jupyterlab/jupyterlab.md
+++ b/docs/guide/jupyterlab/jupyterlab.md
@@ -128,6 +128,13 @@ wish to make a different build the one to be used in DeepESDL JupyterLab,
 change it in the EDIT to the desired conda-build.
 On the bottom of the page you have the possibility to delete the environment.
 
+!!! warning
+
+    Each build consumes storage space, and every modification to an environment creates a new saved build. To help 
+    manage storage more effectively, consider creating new environments with distinct names rather than repeatedly 
+    editing the same one. This makes cleanup much easier, since entire environments can be deleted, whereas individual 
+    build versions within an environment cannot.
+
 ## Getting-started notebooks
 
 You can find example notebooks in DeepESDL JupyterLab to help you to get
@@ -139,7 +146,7 @@ To access them:
     ![img.png](../../img/launcher.png)
     If your `Launcher` is not visible right away, you can open it via the `plus`
     button in the top left corner, which is highlighted in blue in the
-    screenshot.
+    screenshot. 
 2.  On the bottom of the Launcher you see a tile called `CATALOG DeeESDL`.
     Please select this tile.
 3.  Once selected you see several example notebooks:


### PR DESCRIPTION
This PR adds a warning box to custom conda env creation section. 
With accepting the PR the warning will look like this:
<img width="1472" height="625" alt="image" src="https://github.com/user-attachments/assets/2645100b-1d3f-4cbc-8f37-28c717822c23" />

Furthermore this PR fixes the code snippet for opening persisted datacubes in the examples, as the cubes are not publicly available any longer. 